### PR TITLE
Fix password generation API CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# Secure Password
+# Secure Password Studio
+
+A modern web app for generating strong, customizable passwords. Configure length, character sets, and advanced options, then copy the generated password straight into your password manager. The app ships with a lightweight Node.js server and a polished client experience.
+
+## Features
+
+- Adjustable length slider (4–128 characters)
+- Toggle lowercase, uppercase, numeric, and symbol character sets
+- Option to avoid visually similar characters for easier transcription
+- Real-time strength meter with helpful guidance
+- One-click copy support via the Clipboard API
+- No external dependencies required
+
+## Getting started
+
+```bash
+npm install  # optional, no external packages required
+npm start
+```
+
+The app runs at [http://localhost:3000](http://localhost:3000). The server exposes a `POST /api/password` endpoint that accepts JSON payloads matching the generator options.
+
+## API
+
+`POST /api/password`
+
+Request body:
+
+```json
+{
+  "length": 24,
+  "includeLowercase": true,
+  "includeUppercase": true,
+  "includeNumbers": true,
+  "includeSymbols": true,
+  "excludeSimilar": false
+}
+```
+
+Response:
+
+```json
+{
+  "password": "nUEn6U!ktXJ+MhgkqSw5jF@C"
+}
+```
+
+## Development notes
+
+- The server is implemented with Node's built-in `http` module, so it works without network access or external packages.
+- Passwords are generated using cryptographically secure random values from the Node.js `crypto` module.
+- Static assets are served from the `public/` directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "secure-pasword",
+  "version": "1.0.0",
+  "description": "Modern web app for generating secure passwords with customizable options",
+  "main": "server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "password",
+    "generator",
+    "security"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,161 @@
+const form = document.getElementById('password-form');
+const lengthInput = document.getElementById('length');
+const lengthValue = document.getElementById('length-value');
+const passwordOutput = document.getElementById('password');
+const copyButton = document.getElementById('copy');
+const strengthLabel = document.getElementById('strength-label');
+const meterFill = document.getElementById('meter-fill');
+const helperText = document.getElementById('helper-text');
+
+const submitButton = form.querySelector('button[type="submit"]');
+
+lengthValue.textContent = lengthInput.value;
+lengthInput.addEventListener('input', () => {
+  lengthValue.textContent = lengthInput.value;
+  updateStrengthPreview();
+});
+
+form.addEventListener('change', () => {
+  updateStrengthPreview();
+});
+
+form.addEventListener('submit', async event => {
+  event.preventDefault();
+  const payload = getFormPayload();
+
+  if (!payload.includeLowercase && !payload.includeUppercase && !payload.includeNumbers && !payload.includeSymbols) {
+    renderError('Choose at least one character type.');
+    return;
+  }
+
+  submitButton.disabled = true;
+  submitButton.textContent = 'Generating…';
+  helperText.textContent = '';
+
+  try {
+    const response = await fetch('/api/password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json().catch(() => ({ error: 'Unable to generate password.' }));
+      throw new Error(error);
+    }
+
+    const { password } = await response.json();
+    passwordOutput.textContent = password;
+    updateStrengthIndicators(password, payload);
+    helperText.textContent = 'Password generated successfully. Copy it into your password manager right away!';
+  } catch (error) {
+    renderError(error.message || 'Unable to generate password.');
+  } finally {
+    submitButton.disabled = false;
+    submitButton.textContent = 'Generate password';
+  }
+});
+
+copyButton.addEventListener('click', async () => {
+  const password = passwordOutput.textContent.trim();
+  if (!password || password === 'Click generate to get started') {
+    helperText.textContent = 'Generate a password before copying.';
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(password);
+    copyButton.textContent = 'Copied!';
+    helperText.textContent = 'Password copied to your clipboard.';
+    setTimeout(() => {
+      copyButton.textContent = 'Copy';
+    }, 2000);
+  } catch (error) {
+    helperText.textContent = 'Clipboard access is blocked. Copy manually instead.';
+  }
+});
+
+function getFormPayload() {
+  const formData = new FormData(form);
+  return {
+    length: Number(formData.get('length')),
+    includeLowercase: formData.get('includeLowercase') === 'on',
+    includeUppercase: formData.get('includeUppercase') === 'on',
+    includeNumbers: formData.get('includeNumbers') === 'on',
+    includeSymbols: formData.get('includeSymbols') === 'on',
+    excludeSimilar: formData.get('excludeSimilar') === 'on'
+  };
+}
+
+function updateStrengthIndicators(password, payload) {
+  const { score, label, recommendation } = evaluateStrength(password, payload);
+  const width = Math.min(Math.max(score, 10), 100);
+
+  meterFill.style.width = `${width}%`;
+  meterFill.style.background = getStrengthGradient(score);
+  strengthLabel.textContent = `Strength: ${label}`;
+  helperText.textContent = recommendation;
+}
+
+function updateStrengthPreview() {
+  const payload = getFormPayload();
+  const { score, label, recommendation } = evaluateStrength('preview', payload);
+  meterFill.style.width = `${Math.min(Math.max(score, 5), 100)}%`;
+  meterFill.style.background = getStrengthGradient(score);
+  strengthLabel.textContent = `Strength: ${label}`;
+  helperText.textContent = recommendation;
+}
+
+function evaluateStrength(password, options) {
+  const { length, includeLowercase, includeUppercase, includeNumbers, includeSymbols, excludeSimilar } = options;
+  const charsetCount = [includeLowercase, includeUppercase, includeNumbers, includeSymbols].filter(Boolean).length;
+  let score = 0;
+
+  score += Math.min(length * 4, 60);
+  score += charsetCount * 10;
+  if (excludeSimilar) score += 4;
+  if (password.length >= 20) score += 10;
+  if (password.length >= 32) score += 16;
+
+  const normalized = Math.min(score, 100);
+
+  let label = 'Weak';
+  let recommendation = 'Short passwords are easier to crack. Increase the length and mix character types.';
+
+  if (normalized >= 80) {
+    label = 'Exceptional';
+    recommendation = 'This password is highly resilient. Store it securely and rotate it periodically.';
+  } else if (normalized >= 60) {
+    label = 'Strong';
+    recommendation = 'Great job! Consider enabling MFA for the account that uses this password.';
+  } else if (normalized >= 40) {
+    label = 'Moderate';
+    recommendation = 'Strengthen the password by adding symbols or extending the length beyond 16 characters.';
+  }
+
+  if (charsetCount === 0) {
+    label = 'N/A';
+    recommendation = 'Select at least one character type to generate a password.';
+    score = 0;
+  }
+
+  return { score: Math.min(score, 100), label, recommendation };
+}
+
+function getStrengthGradient(score) {
+  if (score >= 75) return 'linear-gradient(90deg, #22c55e, #16a34a)';
+  if (score >= 50) return 'linear-gradient(90deg, #facc15, #f97316)';
+  if (score >= 25) return 'linear-gradient(90deg, #f97316, #ef4444)';
+  return 'linear-gradient(90deg, #ef4444, #dc2626)';
+}
+
+function renderError(message) {
+  passwordOutput.textContent = message;
+  strengthLabel.textContent = 'Strength: —';
+  meterFill.style.width = '0%';
+  helperText.textContent = 'Fix the highlighted issue and try again.';
+}
+
+updateStrengthPreview();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Secure Password Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="background-gradient"></div>
+    <main class="app-shell">
+      <header class="app-header">
+        <h1>Secure Password Studio</h1>
+        <p>
+          Craft ultra-secure passwords tailored to your needs. Choose the perfect
+          length, character sets, and advanced options with real-time strength
+          insights.
+        </p>
+      </header>
+
+      <section class="generator-card">
+        <form id="password-form" class="controls">
+          <div class="control-group">
+            <label for="length">Length</label>
+            <div class="range-control">
+              <input
+                type="range"
+                id="length"
+                name="length"
+                min="4"
+                max="128"
+                value="16"
+              />
+              <span id="length-value" aria-live="polite">16</span>
+            </div>
+          </div>
+
+          <div class="control-grid">
+            <label class="checkbox">
+              <input type="checkbox" id="lowercase" name="includeLowercase" checked />
+              <span>Lowercase (a-z)</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="uppercase" name="includeUppercase" checked />
+              <span>Uppercase (A-Z)</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="numbers" name="includeNumbers" checked />
+              <span>Numbers (0-9)</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="symbols" name="includeSymbols" checked />
+              <span>Symbols (!@#$)</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="excludeSimilar" name="excludeSimilar" />
+              <span>Avoid similar characters</span>
+            </label>
+          </div>
+
+          <div class="button-row">
+            <button type="submit" class="primary">Generate password</button>
+            <button type="button" id="copy" class="secondary" aria-live="polite">
+              Copy
+            </button>
+          </div>
+        </form>
+
+        <div class="output">
+          <div class="password-display" aria-live="polite">
+            <code id="password">Click generate to get started</code>
+          </div>
+          <div class="strength-meter">
+            <span id="strength-label">Strength: —</span>
+            <div class="meter-track">
+              <div id="meter-fill" class="meter-fill"></div>
+            </div>
+          </div>
+          <p class="helper-text" id="helper-text"></p>
+        </div>
+      </section>
+
+      <section class="tips">
+        <h2>Password hygiene tips</h2>
+        <ul>
+          <li>Use a unique password for every account.</li>
+          <li>Combine length with diverse characters for higher entropy.</li>
+          <li>Store generated passwords in a trusted password manager.</li>
+          <li>Enable multi-factor authentication whenever available.</li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,333 @@
+:root {
+  color-scheme: dark light;
+  --surface: rgba(17, 24, 39, 0.75);
+  --surface-light: rgba(255, 255, 255, 0.9);
+  --text-primary: #111827;
+  --text-on-dark: #f9fafb;
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.18);
+  --border: rgba(148, 163, 184, 0.3);
+  --success: #22c55e;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #0f172a;
+  color: var(--text-on-dark);
+}
+
+.background-gradient {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.4), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(236, 72, 153, 0.35), transparent 55%),
+    radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.35), transparent 60%);
+  filter: blur(40px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.app-shell {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2rem;
+  padding: 4rem 1.5rem 6rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.app-header {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+.app-header p {
+  margin: 0 auto;
+  max-width: 52ch;
+  color: rgba(248, 250, 252, 0.75);
+  font-size: 1.05rem;
+}
+
+.generator-card {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.6));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 2rem;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+}
+
+.controls {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.control-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.control-group label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.range-control {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.range-control input[type='range'] {
+  flex: 1;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  outline: none;
+}
+
+.range-control input[type='range']::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 0 6px var(--accent-soft);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.range-control input[type='range']::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 0 6px var(--accent-soft);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.range-control input[type='range']:active::-webkit-slider-thumb,
+.range-control input[type='range']:active::-moz-range-thumb {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 10px var(--accent-soft);
+}
+
+#length-value {
+  font-weight: 600;
+  min-width: 2ch;
+  text-align: right;
+}
+
+.control-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(4px);
+  transition: border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.checkbox:hover {
+  border-color: rgba(129, 140, 248, 0.7);
+  background: rgba(99, 102, 241, 0.16);
+}
+
+.checkbox input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1.5px solid rgba(148, 163, 184, 0.7);
+  accent-color: var(--accent);
+  margin: 0;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: white;
+  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.35);
+}
+
+button.primary:hover,
+button.secondary:hover {
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text-on-dark);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.output {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.password-display {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.1rem;
+  padding: 1.5rem;
+  font-size: clamp(1.1rem, 2.8vw, 1.45rem);
+  letter-spacing: 0.05em;
+  min-height: 3.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.password-display code {
+  word-break: break-all;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.strength-meter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.meter-track {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.meter-fill {
+  height: 100%;
+  width: 10%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #f97316, #facc15);
+  transition: width 0.3s ease, background 0.3s ease;
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.tips {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: 1rem;
+}
+
+.tips h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.tips ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+@media (max-width: 720px) {
+  .generator-card {
+    padding: 1.75rem;
+  }
+
+  .button-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    width: 100%;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background: #f8fafc;
+    color: var(--text-primary);
+  }
+
+  .background-gradient {
+    opacity: 0.5;
+  }
+
+  .generator-card,
+  .tips {
+    background: rgba(255, 255, 255, 0.86);
+    border-color: rgba(203, 213, 225, 0.6);
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+    color: var(--text-primary);
+  }
+
+  .password-display {
+    background: rgba(248, 250, 252, 0.95);
+    border-color: rgba(203, 213, 225, 0.5);
+    color: var(--text-primary);
+  }
+
+  .password-display code {
+    color: var(--text-primary);
+  }
+
+  .helper-text {
+    color: rgba(71, 85, 105, 0.8);
+  }
+
+  button.secondary {
+    color: var(--text-primary);
+    border-color: rgba(99, 102, 241, 0.25);
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,234 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 3000;
+const API_PATH = '/api/password';
+const publicDir = path.join(__dirname, 'public');
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Vary': 'Origin'
+};
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon'
+};
+
+function generatePassword(options) {
+  const {
+    length = 16,
+    includeLowercase = true,
+    includeUppercase = true,
+    includeNumbers = true,
+    includeSymbols = true,
+    excludeSimilar = false
+  } = options || {};
+
+  const pools = [];
+  const requiredChars = [];
+
+  if (includeLowercase) {
+    const lowercase = excludeSimilar ? 'abcdefghjkmnpqrstuvwxyz' : 'abcdefghijklmnopqrstuvwxyz';
+    pools.push(lowercase);
+    requiredChars.push(pickRandomChar(lowercase));
+  }
+
+  if (includeUppercase) {
+    const uppercase = excludeSimilar ? 'ABCDEFGHJKMNPQRSTUVWXYZ' : 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    pools.push(uppercase);
+    requiredChars.push(pickRandomChar(uppercase));
+  }
+
+  if (includeNumbers) {
+    const numbers = excludeSimilar ? '23456789' : '0123456789';
+    pools.push(numbers);
+    requiredChars.push(pickRandomChar(numbers));
+  }
+
+  if (includeSymbols) {
+    const symbols = '!@#$%^&*()-_=+[]{}|;:,.<>?/';
+    pools.push(symbols);
+    requiredChars.push(pickRandomChar(symbols));
+  }
+
+  if (!pools.length) {
+    throw new Error('At least one character set must be selected.');
+  }
+
+  const allowedChars = pools.join('');
+  const passwordChars = [...requiredChars];
+
+  while (passwordChars.length < length) {
+    passwordChars.push(pickRandomChar(allowedChars));
+  }
+
+  // Shuffle the characters using Fisher-Yates
+  for (let i = passwordChars.length - 1; i > 0; i--) {
+    const j = secureRandomInt(i + 1);
+    [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
+  }
+
+  return passwordChars.join('').slice(0, length);
+}
+
+function pickRandomChar(pool) {
+  if (!pool || pool.length === 0) {
+    throw new Error('Character pool must contain at least one character.');
+  }
+  const index = secureRandomInt(pool.length);
+  return pool[index];
+}
+
+function secureRandomInt(maxExclusive) {
+  if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+    throw new Error('Maximum value must be a positive number.');
+  }
+
+  if (typeof crypto.randomInt === 'function') {
+    return crypto.randomInt(0, maxExclusive);
+  }
+
+  const maxUint = 0xffffffff;
+  const limit = Math.floor((maxUint + 1) / maxExclusive) * maxExclusive;
+
+  while (true) {
+    const randomNumber = crypto.randomBytes(4).readUInt32BE(0);
+    if (randomNumber < limit) {
+      return randomNumber % maxExclusive;
+    }
+  }
+}
+
+function sanitizePath(requestPath) {
+  const normalized = path.normalize(requestPath);
+  if (normalized === '/' || normalized === '\\') {
+    return '/index.html';
+  }
+  return normalized;
+}
+
+function serveStaticFile(filePath, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('404 Not Found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('500 Internal Server Error');
+      }
+      return;
+    }
+
+    const ext = path.extname(filePath);
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+function handlePasswordRequest(req, res) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+    if (body.length > 1e6) {
+      req.socket.destroy();
+    }
+  });
+
+  req.on('end', () => {
+    try {
+      const payload = body ? JSON.parse(body) : {};
+      const length = Math.min(Math.max(parseInt(payload.length, 10) || 0, 4), 128);
+      const options = {
+        length,
+        includeLowercase: Boolean(payload.includeLowercase),
+        includeUppercase: Boolean(payload.includeUppercase),
+        includeNumbers: Boolean(payload.includeNumbers),
+        includeSymbols: Boolean(payload.includeSymbols),
+        excludeSimilar: Boolean(payload.excludeSimilar)
+      };
+
+      if (Number.isNaN(length) || length <= 0) {
+        throw new Error('Password length must be a positive number.');
+      }
+
+      const password = generatePassword(options);
+
+      res.writeHead(200, {
+        ...corsHeaders,
+        'Content-Type': 'application/json; charset=utf-8'
+      });
+      res.end(JSON.stringify({ password }));
+    } catch (err) {
+      res.writeHead(400, {
+        ...corsHeaders,
+        'Content-Type': 'application/json; charset=utf-8'
+      });
+      res.end(JSON.stringify({ error: err.message || 'Unable to generate password' }));
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+
+  if (requestUrl.pathname === API_PATH) {
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        ...corsHeaders,
+        'Content-Length': '0'
+      });
+      res.end();
+      return;
+    }
+
+    if (req.method === 'POST') {
+      return handlePasswordRequest(req, res);
+    }
+
+    res.writeHead(405, {
+      ...corsHeaders,
+      'Content-Type': 'application/json; charset=utf-8'
+    });
+    res.end(JSON.stringify({ error: 'Method not allowed.' }));
+    return;
+  }
+
+  const sanitizedPath = sanitizePath(requestUrl.pathname);
+  const filePath = path.join(publicDir, decodeURIComponent(sanitizedPath));
+
+  if (!filePath.startsWith(publicDir)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('403 Forbidden');
+    return;
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      serveStaticFile(path.join(publicDir, 'index.html'), res);
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      serveStaticFile(path.join(filePath, 'index.html'), res);
+    } else {
+      serveStaticFile(filePath, res);
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Secure password generator server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add reusable CORS headers and OPTIONS handling so the password endpoint works across browser contexts
- fall back to a crypto.randomBytes based generator when crypto.randomInt is unavailable while keeping Fisher-Yates shuffling secure
- return consistent JSON responses for unsupported methods and errors on the password API

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68d6a7ad185c832c915937ce896b447c