### PR TITLE
Refactor password handler into shared module

### DIFF
--- a/api/password.js
+++ b/api/password.js
@@ -1,0 +1,11 @@
+const { handlePasswordRequest } = require('../lib/password');
+
+module.exports = (req, res) => {
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  handlePasswordRequest(req, res);
+};

--- a/lib/password.js
+++ b/lib/password.js
@@ -1,0 +1,112 @@
+const crypto = require('crypto');
+
+function pickRandomChar(pool) {
+  if (!pool || pool.length === 0) {
+    throw new Error('Character pool must contain at least one character.');
+  }
+  const index = crypto.randomInt(0, pool.length);
+  return pool[index];
+}
+
+function generatePassword(options) {
+  const {
+    length = 16,
+    includeLowercase = true,
+    includeUppercase = true,
+    includeNumbers = true,
+    includeSymbols = true,
+    excludeSimilar = false
+  } = options || {};
+
+  const pools = [];
+  const requiredChars = [];
+
+  if (includeLowercase) {
+    const lowercase = excludeSimilar ? 'abcdefghjkmnpqrstuvwxyz' : 'abcdefghijklmnopqrstuvwxyz';
+    pools.push(lowercase);
+    requiredChars.push(pickRandomChar(lowercase));
+  }
+
+  if (includeUppercase) {
+    const uppercase = excludeSimilar ? 'ABCDEFGHJKMNPQRSTUVWXYZ' : 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    pools.push(uppercase);
+    requiredChars.push(pickRandomChar(uppercase));
+  }
+
+  if (includeNumbers) {
+    const numbers = excludeSimilar ? '23456789' : '0123456789';
+    pools.push(numbers);
+    requiredChars.push(pickRandomChar(numbers));
+  }
+
+  if (includeSymbols) {
+    const symbols = '!@#$%^&*()-_=+[]{}|;:,.<>?/';
+    pools.push(symbols);
+    requiredChars.push(pickRandomChar(symbols));
+  }
+
+  if (!pools.length) {
+    throw new Error('At least one character set must be selected.');
+  }
+
+  const allowedChars = pools.join('');
+  const passwordChars = [...requiredChars];
+
+  while (passwordChars.length < length) {
+    passwordChars.push(pickRandomChar(allowedChars));
+  }
+
+  for (let i = passwordChars.length - 1; i > 0; i--) {
+    const j = crypto.randomInt(0, i + 1);
+    [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
+  }
+
+  return passwordChars.join('').slice(0, length);
+}
+
+function buildOptions(payload) {
+  const length = Math.min(Math.max(parseInt(payload.length, 10) || 0, 4), 128);
+
+  if (Number.isNaN(length) || length <= 0) {
+    throw new Error('Password length must be a positive number.');
+  }
+
+  return {
+    length,
+    includeLowercase: Boolean(payload.includeLowercase),
+    includeUppercase: Boolean(payload.includeUppercase),
+    includeNumbers: Boolean(payload.includeNumbers),
+    includeSymbols: Boolean(payload.includeSymbols),
+    excludeSimilar: Boolean(payload.excludeSimilar)
+  };
+}
+
+function handlePasswordRequest(req, res) {
+  let body = '';
+
+  req.on('data', chunk => {
+    body += chunk;
+    if (body.length > 1e6) {
+      req.socket.destroy();
+    }
+  });
+
+  req.on('end', () => {
+    try {
+      const payload = body ? JSON.parse(body) : {};
+      const options = buildOptions(payload);
+      const password = generatePassword(options);
+
+      res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ password }));
+    } catch (err) {
+      res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ error: err.message || 'Unable to generate password' }));
+    }
+  });
+}
+
+module.exports = {
+  generatePassword,
+  handlePasswordRequest
+};

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const { URL } = require('url');
-const crypto = require('crypto');
+const { handlePasswordRequest } = require('./lib/password');
 
 const PORT = process.env.PORT || 3000;
 const publicDir = path.join(__dirname, 'public');
@@ -16,71 +16,6 @@ const mimeTypes = {
   '.png': 'image/png',
   '.ico': 'image/x-icon'
 };
-
-function generatePassword(options) {
-  const {
-    length = 16,
-    includeLowercase = true,
-    includeUppercase = true,
-    includeNumbers = true,
-    includeSymbols = true,
-    excludeSimilar = false
-  } = options || {};
-
-  const pools = [];
-  const requiredChars = [];
-
-  if (includeLowercase) {
-    const lowercase = excludeSimilar ? 'abcdefghjkmnpqrstuvwxyz' : 'abcdefghijklmnopqrstuvwxyz';
-    pools.push(lowercase);
-    requiredChars.push(pickRandomChar(lowercase));
-  }
-
-  if (includeUppercase) {
-    const uppercase = excludeSimilar ? 'ABCDEFGHJKMNPQRSTUVWXYZ' : 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    pools.push(uppercase);
-    requiredChars.push(pickRandomChar(uppercase));
-  }
-
-  if (includeNumbers) {
-    const numbers = excludeSimilar ? '23456789' : '0123456789';
-    pools.push(numbers);
-    requiredChars.push(pickRandomChar(numbers));
-  }
-
-  if (includeSymbols) {
-    const symbols = '!@#$%^&*()-_=+[]{}|;:,.<>?/';
-    pools.push(symbols);
-    requiredChars.push(pickRandomChar(symbols));
-  }
-
-  if (!pools.length) {
-    throw new Error('At least one character set must be selected.');
-  }
-
-  const allowedChars = pools.join('');
-  const passwordChars = [...requiredChars];
-
-  while (passwordChars.length < length) {
-    passwordChars.push(pickRandomChar(allowedChars));
-  }
-
-  // Shuffle the characters using Fisher-Yates
-  for (let i = passwordChars.length - 1; i > 0; i--) {
-    const j = crypto.randomInt(0, i + 1);
-    [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
-  }
-
-  return passwordChars.join('').slice(0, length);
-}
-
-function pickRandomChar(pool) {
-  if (!pool || pool.length === 0) {
-    throw new Error('Character pool must contain at least one character.');
-  }
-  const index = crypto.randomInt(0, pool.length);
-  return pool[index];
-}
 
 function sanitizePath(requestPath) {
   const normalized = path.normalize(requestPath);
@@ -110,44 +45,7 @@ function serveStaticFile(filePath, res) {
   });
 }
 
-function handlePasswordRequest(req, res) {
-  let body = '';
-  req.on('data', chunk => {
-    body += chunk;
-    if (body.length > 1e6) {
-      req.socket.destroy();
-    }
-  });
-
-  req.on('end', () => {
-    try {
-      const payload = body ? JSON.parse(body) : {};
-      const length = Math.min(Math.max(parseInt(payload.length, 10) || 0, 4), 128);
-      const options = {
-        length,
-        includeLowercase: Boolean(payload.includeLowercase),
-        includeUppercase: Boolean(payload.includeUppercase),
-        includeNumbers: Boolean(payload.includeNumbers),
-        includeSymbols: Boolean(payload.includeSymbols),
-        excludeSimilar: Boolean(payload.excludeSimilar)
-      };
-
-      if (Number.isNaN(length) || length <= 0) {
-        throw new Error('Password length must be a positive number.');
-      }
-
-      const password = generatePassword(options);
-
-      res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-      res.end(JSON.stringify({ password }));
-    } catch (err) {
-      res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
-      res.end(JSON.stringify({ error: err.message || 'Unable to generate password' }));
-    }
-  });
-}
-
-const server = http.createServer((req, res) => {
+function requestListener(req, res) {
   const requestUrl = new URL(req.url, `http://${req.headers.host}`);
 
   if (requestUrl.pathname === '/api/password' && req.method === 'POST') {
@@ -175,8 +73,13 @@ const server = http.createServer((req, res) => {
       serveStaticFile(filePath, res);
     }
   });
-});
+}
 
-server.listen(PORT, () => {
-  console.log(`Secure password generator server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  const server = http.createServer(requestListener);
+  server.listen(PORT, () => {
+    console.log(`Secure password generator server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = { requestListener };


### PR DESCRIPTION
## Summary
- extract the password generation and request handling logic into `lib/password.js` for reuse
- add `api/password.js` to expose the shared handler for the `/api/password` serverless endpoint
- update `server.js` to consume the shared handler and only start the HTTP server when run directly

## Testing
- node -e "const { generatePassword } = require('./lib/password'); console.log(generatePassword({ length: 12 }));"

------
https://chatgpt.com/codex/tasks/task_e_68d6b1979e10832ca04d149ffc980e16